### PR TITLE
global: avoid building and testing as root

### DIFF
--- a/bionic.Dockerfile
+++ b/bionic.Dockerfile
@@ -5,3 +5,5 @@ RUN apt-get update
 RUN apt-get -y install pkgconf clang git cmake curl libssl-dev libcurl4 libcurl4-openssl-dev libssh2-1-dev libz-dev valgrind openssh-client openssh-server
 RUN if [ "$ARCH" != "armhf" -a "$ARCH" != "arm64" ]; then apt-get -y install openjdk-11-jre-headless; fi
 RUN mkdir /var/run/sshd
+RUN useradd --create-home libgit2
+USER libgit2

--- a/centos.Dockerfile
+++ b/centos.Dockerfile
@@ -9,4 +9,6 @@ WORKDIR "/tmp/libssh2-1.8.0"
 RUN ./configure
 RUN make
 RUN make install
+RUN useradd --create-home libgit2
+USER libgit2
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig

--- a/fedora.Dockerfile
+++ b/fedora.Dockerfile
@@ -9,4 +9,6 @@ WORKDIR "/tmp/libssh2-1.8.0"
 RUN ./configure
 RUN make
 RUN make install
+RUN useradd --create-home libgit2
+USER libgit2
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig

--- a/trusty.Dockerfile
+++ b/trusty.Dockerfile
@@ -18,3 +18,6 @@ RUN (cd /tmp/mbedtls && make install)
 RUN rm -rf /tmp/mbedtls
 
 RUN mkdir /var/run/sshd
+
+RUN useradd --create-home libgit2
+USER libgit2

--- a/xenial.Dockerfile
+++ b/xenial.Dockerfile
@@ -4,3 +4,6 @@ ARG CACHEBUST=1
 RUN apt-get update
 RUN apt-get -y install pkgconf clang git cmake curl libssl-dev libcurl3 libcurl3-gnutls libcurl4-gnutls-dev valgrind openssh-client openssh-server openjdk-8-jre
 RUN mkdir /var/run/sshd
+
+RUN useradd --create-home libgit2
+USER libgit2


### PR DESCRIPTION
Right now, all tests in libgit2's CI are being executed as root
user. As libgit2 will usually not run as a root user in "normal"
usecases and furthermore as there are tests that rely on the
ability to _not_ be able to create certain paths, let's instead
create an unprivileged user "libgit2" and use that across all
docker images.

---

Two possibilities: we could either create an entry point that chowns the build volume for us so that we can write into it, or alternatively we could `chmod a+rwx` it in "azure-pipelines/docker.yml". I'd personally vote for the latter